### PR TITLE
Switch to on.pull_request_target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
+
 env:
   AWS_GITHUB_OIDC_ROLE: ${{ vars.AWS_OIDC_ROLE_ARN }}
   AWS_GITHUB_ACTIONS_ROLE: ${{ vars.AWS_GITHUB_ACTIONS_ROLE_ARN }}


### PR DESCRIPTION
It uses `on.pull_request_target` instead of `on.pull_request` for security, so it only runs a workflow that's already committed to the target branch, not from the pull request.