### PR TITLE
Added note about having to send settings before enabling map reporting

### DIFF
--- a/content/docs/configuration/index.md
+++ b/content/docs/configuration/index.md
@@ -43,6 +43,9 @@ If you would like to connect your nodes to the MQTT broker and provide telemetry
   * JSON Enabled: `Unchecked`
   * TLS Enabled: *user preference* \*
   * Root topic: `msh/US/FL`
+  
+  *\* Note: If you followed the above MQTT steps in order, then you need to hit "Send" to update the device at this point before you proceed to the below four steps. Otherwise the send button will be grayed out.*
+  
   * Map reporting: `Checked`
   * Map reporting interval (seconds): `10800`
   * Precise location: *user preference*


### PR DESCRIPTION
If you update the MQTT server settings and then don't hit the send button before moving on to the map reporting section in the MQTT config steps, then the send button will forever be grayed out with absolutely no explanation why, leading to a very confusing user experience.

Simply sending after the MQTT server settings are input, then moving on to configuring map reporting will allow you to configure in the order shown