### PR TITLE
Added maximum setting for hop limit due to detriment to mesh

### DIFF
--- a/content/docs/configuration/index.md
+++ b/content/docs/configuration/index.md
@@ -30,6 +30,7 @@ If you would like to connect your nodes to the MQTT broker and provide telemetry
     * Precision Slider: *user preference*
 
   LoRa:
+  * Hop limit: `3, except in specific use cases` *(user preference: but do not set to higher than 5)*
   * Ignore MQTT: `Unchecked`
   * OK to MQTT: `Checked`
 


### PR DESCRIPTION
Figure this should be included because it's one of those settings people see and go "Oh! More = more better!" and it's bad for the mesh.

I would like to be able to point anyone to this page as a first-time-node-config and this is one of those gotcha settings