### PR TITLE
Enhance configuration files: Add node permissions to hugo.yaml, update language label and author in languages.yaml, and introduce new repo-id.html partial for Giscus integration.

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -2,9 +2,9 @@ version: 1
 env:
   variables:
     # Application versions
-    DART_SASS_VERSION: 1.87.0
+    DART_SASS_VERSION: 1.99.0
     GO_VERSION: 1.24.2
-    HUGO_VERSION: 0.147.7
+    HUGO_VERSION: 0.162.1
     # Time zone
     TZ: America/New_York
     # Cache

--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -67,3 +67,7 @@ security:
       - CI$
       - PWD
 
+  node:
+    permissions:
+      allowRead:
+        - "*"

--- a/config/_default/languages.yaml
+++ b/config/_default/languages.yaml
@@ -1,3 +1,6 @@
 en:
-  languageName: English
+  label: English
   weight: 1
+  params:
+    author:
+      name: "Jeremy T. Bouse"

--- a/layouts/partials/giscus/repo-id.html
+++ b/layouts/partials/giscus/repo-id.html
@@ -1,0 +1,14 @@
+{{- $url := printf "https://api.github.com/repos/%s" . -}}
+{{- $data := dict -}}
+
+{{- with try (resources.GetRemote $url) -}}
+  {{- with .Err -}}
+    {{- errorf "%s" . -}}
+  {{- else with .Value -}}
+    {{- $data = . | transform.Unmarshal -}}
+  {{- else -}}
+    {{- errorf "Unable to get remote resource %q" $url -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $data.node_id -}}


### PR DESCRIPTION
Upgrade to run hugo 0.162.1