### PR TITLE
Add bots and automation guidance, and Florida channel tables

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -74,6 +74,10 @@ hb:
   google_fonts:
     families:
       - name: Ubuntu
+        axis:
+          wght:
+            - 400
+            - 700
   back_to_top:
     icon_name: radioactive
   sass_silence_deprecations:

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -12,7 +12,7 @@ menu:
 
 Florida Mesh Documentations, How-tos and Configuration Setup Guides.
 
-Start with the [Introduction][introduction], then follow the section for your network, either [Meshtastic][meshtastic-docs] or [Meshcore][meshcore-docs]. Each section covers regional settings, node configuration, and installation. The [Weekly Mesh Net][weekly-net] runs on both networks at the same time.
+Start with the [Introduction][introduction], then follow the section for your network, either [Meshtastic][meshtastic-docs] or [MeshCore][meshcore-docs]. Each section covers regional settings, node configuration, and installation. The [Weekly Mesh Net][weekly-net] runs on both networks at the same time.
 
 [introduction]: introduction
 [meshtastic-docs]: meshtastic

--- a/content/docs/general/bots-and-automation/index.md
+++ b/content/docs/general/bots-and-automation/index.md
@@ -31,8 +31,8 @@ Automation earns its airtime in plenty of places: severe weather and emergency a
 - **Avoid replying on the default public channel.** Use one of the above two methods or choose an appropriate [MeshCore]({{< relref "/docs/meshcore/configuration/index.md" >}}#channels) or [Meshtastic]({{< relref "/docs/meshtastic/configuration/index.md" >}}#channels) channel.
 - Keep replies concise and pertinent.
 - Consider your reach. Local weather forecasts and the functional status of your automated responder do not belong on an MQTT uplinked channel that reaches nodes across the state.
-- When in doubt, start small and on a private channel.
 - If the content is something people fetch rather than something they need pushed to them, consider a BBS or Room Server.
+- When in doubt, start small and on a private channel.
 
 ## Projects worth looking at
 

--- a/content/docs/general/bots-and-automation/index.md
+++ b/content/docs/general/bots-and-automation/index.md
@@ -16,35 +16,31 @@ series:
   - Guide
 ---
 
-Bots, scripts, and AI responders are welcome on the Florida mesh. They are also the easiest way to fill the shared channels with traffic nobody asked for, so this page describes where automation belongs.
+Conventions for running automation on the Florida mesh. Automation here means anything that transmits without a person pressing send: auto-replies, scripts, alerting integrations, and AI agents.
 
 <!--more-->
 
-Automation here means anything that transmits without a person pressing send: auto-replies, scripts, alerting integrations, and AI agents.
-
 ## Where to run it
 
-- Reply by direct message. A bot that answers the person who called it has no reason to broadcast.
-- Run on a channel meant for it. Bots talking to bots, and anyone experimenting with AI on the mesh, belong on the testing channel or a private one. Weather scripts belong on the weather channel.
-- Leave the emergency channel clear. It has to stay quiet enough to be useful the day it matters.
-- Use a tapback instead of a text reply where the app supports one. It confirms receipt without adding a message.
+- **Reply by direct message.** A bot answering the node that called it does not need to broadcast.
+- **Use a channel meant for it.** Bot-to-bot traffic and AI experiments go on the testing channel or a private one. Weather scripts go on the weather channel.
+- **Keep the emergency channel clear.** Emergency traffic only.
+- **Prefer a tapback to a text reply** where the app supports one. It acknowledges without a second message.
 
-Two bots answering each other on a shared channel is the failure everyone notices, and it is the one these habits prevent.
+An auto-reply that triggers on another bot's auto-reply loops until one of them stops. Reply by DM, or filter on sender, or both.
 
 ## Label it as a bot
 
-Put `bot` in the node name, and in the short name where the app has one. Someone reading a channel should be able to tell at a glance whether a message came from a person, a script, or a model, without already knowing which nodes are which.
-
-It costs nothing and it is what makes everything else on this page work. A reader who can spot automation can decide what to do about it.
+Put `bot` in the node name, and in the short name where the app has one. A reader scanning a channel can then separate scripted traffic from human traffic without knowing the nodes.
 
 ## Public channel traffic
 
-Some automation does belong on the public channel. Emergency and severe weather alerting is the clear case: low volume, high value, and nothing for another bot to reply to.
+Emergency and severe weather alerting is the case that justifies the public channel: low volume, high value, no reply loop.
 
-Coordinate before starting one. Several operators relaying the same feed multiplies the traffic without adding information, and an alert meant for one county reaches the whole state if nothing scopes it. Ask on Discord first.
+Coordinate before running one. Duplicate relays of the same feed multiply traffic without adding information, and an alert scoped to one county floods the state unless something limits it. Ask on Discord first.
 
 ## Channel names
 
-The everyday channels use the same names on both networks so operators do not have to learn two sets. The lists are in [MeshCore Node Configuration]({{< relref "/docs/meshcore/configuration/index.md" >}}#channels) and [Meshtastic Node Configuration]({{< relref "/docs/meshtastic/configuration/index.md" >}}#channels).
+The everyday channels use the same names on both networks. The lists, keys, and add links are in [MeshCore Node Configuration]({{< relref "/docs/meshcore/configuration/index.md" >}}#channels) and [Meshtastic Node Configuration]({{< relref "/docs/meshtastic/configuration/index.md" >}}#channels).
 
-None of this is enforced. Neither network has an operator who could enforce it. It works only as a convention people choose to follow.
+Neither network has an operator who can enforce any of this. It holds as a convention or not at all.

--- a/content/docs/general/bots-and-automation/index.md
+++ b/content/docs/general/bots-and-automation/index.md
@@ -20,11 +20,7 @@ Conventions for running automation on the Florida mesh. Automation here means an
 
 <!--more-->
 
-## Airtime is the cost, not screen clutter
-
-Notifications are the visible symptom. The real constraint is airtime: one channel, shared by everyone in range, and every transmission occupies it while repeaters carry it further. Traffic that nobody needed still displaces traffic somebody did.
-
-Automation cuts both ways here. A bot that answers a common question once, by direct message, can lower total traffic by saving five people from asking it on a public channel, and a well-scoped alerting feed can replace a scattered conversation. A bot that acknowledges every message, retries on failure, or answers other bots spends the same airtime and returns nothing. The difference is implementation, not intent.
+Airtime is shared and finite: one frequency for every node in range, used again by each repeater that forwards a packet. A bot that answers by direct message saves airtime. One that replies to everything, retries failures, or answers other bots wastes it.
 
 ## Where to run it
 

--- a/content/docs/general/bots-and-automation/index.md
+++ b/content/docs/general/bots-and-automation/index.md
@@ -1,0 +1,44 @@
+---
+title: Bots and Automation
+linkTitle: Bots
+description: Where bots, scripts, and automated responses belong on the Florida mesh.
+date: 2026-08-16T00:00:00-04:00
+draft: false
+noindex: false
+nav_weight: 1000
+nav_icon:
+  vendor: bs
+  name: robot
+  color: '#6be'
+authors:
+  - beanfield
+series:
+  - Guide
+---
+
+Bots, scripts, and AI responders are welcome on the Florida mesh. They are also the easiest way to fill the shared channels with traffic nobody asked for, so this page describes where automation belongs.
+
+<!--more-->
+
+Automation here means anything that transmits without a person pressing send: auto-replies, scripts, alerting integrations, and AI agents.
+
+## Where to run it
+
+- Reply by direct message. A bot that answers the person who called it has no reason to broadcast.
+- Run on a channel meant for it. Bots talking to bots, and anyone experimenting with AI on the mesh, belong on the testing channel or a private one. Weather scripts belong on the weather channel.
+- Leave the emergency channel clear. It has to stay quiet enough to be useful the day it matters.
+- Use a tapback instead of a text reply where the app supports one. It confirms receipt without adding a message.
+
+Two bots answering each other on a shared channel is the failure everyone notices, and it is the one these three habits prevent.
+
+## Public channel traffic
+
+Some automation does belong on the public channel. Emergency and severe weather alerting is the clear case: low volume, high value, and nothing for another bot to reply to.
+
+Coordinate before starting one. Several operators relaying the same feed multiplies the traffic without adding information, and an alert meant for one county reaches the whole state if nothing scopes it. Ask on Discord first.
+
+## Channel names
+
+The everyday channels use the same names on both networks so operators do not have to learn two sets. The lists are in [MeshCore Node Configuration]({{< relref "/docs/meshcore/configuration/index.md" >}}#channels) and [Meshtastic Node Configuration]({{< relref "/docs/meshtastic/configuration/index.md" >}}#channels).
+
+None of this is enforced. Neither network has an operator who could enforce it. It works only as a convention people choose to follow.

--- a/content/docs/general/bots-and-automation/index.md
+++ b/content/docs/general/bots-and-automation/index.md
@@ -42,5 +42,3 @@ Coordinate before running one. Duplicate relays of the same feed multiply traffi
 ## Channel names
 
 The everyday channels use the same names on both networks. The lists, keys, and add links are in [MeshCore Node Configuration]({{< relref "/docs/meshcore/configuration/index.md" >}}#channels) and [Meshtastic Node Configuration]({{< relref "/docs/meshtastic/configuration/index.md" >}}#channels).
-
-Neither network has an operator who can enforce any of this. It holds as a convention or not at all.

--- a/content/docs/general/bots-and-automation/index.md
+++ b/content/docs/general/bots-and-automation/index.md
@@ -29,7 +29,13 @@ Automation here means anything that transmits without a person pressing send: au
 - Leave the emergency channel clear. It has to stay quiet enough to be useful the day it matters.
 - Use a tapback instead of a text reply where the app supports one. It confirms receipt without adding a message.
 
-Two bots answering each other on a shared channel is the failure everyone notices, and it is the one these three habits prevent.
+Two bots answering each other on a shared channel is the failure everyone notices, and it is the one these habits prevent.
+
+## Label it as a bot
+
+Put `bot` in the node name, and in the short name where the app has one. Someone reading a channel should be able to tell at a glance whether a message came from a person, a script, or a model, without already knowing which nodes are which.
+
+It costs nothing and it is what makes everything else on this page work. A reader who can spot automation can decide what to do about it.
 
 ## Public channel traffic
 

--- a/content/docs/general/bots-and-automation/index.md
+++ b/content/docs/general/bots-and-automation/index.md
@@ -20,6 +20,12 @@ Conventions for running automation on the Florida mesh. Automation here means an
 
 <!--more-->
 
+## Airtime is the cost, not screen clutter
+
+Notifications are the visible symptom. The real constraint is airtime: one channel, shared by everyone in range, and every transmission occupies it while repeaters carry it further. Traffic that nobody needed still displaces traffic somebody did.
+
+Automation cuts both ways here. A bot that answers a common question once, by direct message, can lower total traffic by saving five people from asking it on a public channel, and a well-scoped alerting feed can replace a scattered conversation. A bot that acknowledges every message, retries on failure, or answers other bots spends the same airtime and returns nothing. The difference is implementation, not intent.
+
 ## Where to run it
 
 - **Reply by direct message.** A bot answering the node that called it does not need to broadcast.
@@ -28,6 +34,12 @@ Conventions for running automation on the Florida mesh. Automation here means an
 - **Prefer a tapback to a text reply** where the app supports one. It acknowledges without a second message.
 
 An auto-reply that triggers on another bot's auto-reply loops until one of them stops. Reply by DM, or filter on sender, or both.
+
+## Consider a room server instead
+
+If the content is something people fetch rather than something they need pushed to them, a MeshCore room server or a bulletin board is often the better mechanism. Messages sit on the server until a client connects and reads them, so the cost is one exchange with one node at a time the reader chose, rather than a broadcast every radio in range has to carry whether or not anyone wanted it.
+
+Bulletins, net announcements, reference material, and logs all fit that shape. Time-critical alerts do not, which is why emergency and severe weather alerting stays on a channel.
 
 ## Label it as a bot
 

--- a/content/docs/general/bots-and-automation/index.md
+++ b/content/docs/general/bots-and-automation/index.md
@@ -20,33 +20,22 @@ Conventions for running automation on the Florida mesh. Automation here means an
 
 <!--more-->
 
-Airtime is shared and finite: one frequency for every node in range, used again by each repeater that forwards a packet. A bot that answers by direct message saves airtime. One that replies to everything, retries failures, or answers other bots wastes it.
+Automation earns its airtime in plenty of places: severe weather and emergency alerting, range validation, equipment testing, new user onboarding, and proximity alerts. Not all of them belong on every channel. Remember, airtime is shared and finite: one frequency for every node in range, used again by each repeater that forwards a packet. A bot that answers by direct message saves airtime. One that replies to everything, retries failures, or answers other bots wastes it and creates noise.
 
-## Where to run it
+## Best Practices
 
-- **Reply by direct message.** A bot answering the node that called it does not need to broadcast.
-- **Use a channel meant for it.** Bot-to-bot traffic and AI experiments go on the testing channel or a private one. Weather scripts go on the weather channel.
-- **Keep the emergency channel clear.** Emergency traffic only.
-- **Prefer a tapback to a text reply** where the app supports one. It acknowledges without a second message.
+- **Keep the emergency channels clear.** Emergency traffic only.
+- Add the word `bot` to your node name to make it easy for users and other automated responders to identify.
+- **Reply by direct message, not the channel.** A bot answering the node that called it does not need to broadcast. Direct messages are also cheaper on the air: both networks learn a path to the destination and route later messages along it rather than flooding the mesh, [Meshtastic](https://meshtastic.org/docs/overview/mesh-algo/) with next-hop routing and [MeshCore](https://docs.meshcore.io/faq/#54-q-how-does-a-node-discover-a-path-to-its-destination-and-then-use-it-to-send-messages-in-the-future-instead-of-flooding-every-message-it-sends-like-meshtastic) with the path recorded in the delivery report.
+- **Use tapbacks** where the app supports one. It acknowledges without a second message.
+- **Avoid replying on the default public channel.** Use one of the above two methods or choose an appropriate [MeshCore]({{< relref "/docs/meshcore/configuration/index.md" >}}#channels) or [Meshtastic]({{< relref "/docs/meshtastic/configuration/index.md" >}}#channels) channel.
+- Keep replies concise and pertinent.
+- Consider your reach. Local weather forecasts and the functional status of your automated responder do not belong on an MQTT uplinked channel that reaches nodes across the state.
+- When in doubt, start small and on a private channel.
+- If the content is something people fetch rather than something they need pushed to them, consider a BBS or Room Server.
 
-An auto-reply that triggers on another bot's auto-reply loops until one of them stops. Reply by DM, or filter on sender, or both.
+## Projects worth looking at
 
-## Consider a room server instead
-
-If the content is something people fetch rather than something they need pushed to them, a MeshCore room server or a bulletin board is often the better mechanism. Messages sit on the server until a client connects and reads them, so the cost is one exchange with one node at a time the reader chose, rather than a broadcast every radio in range has to carry whether or not anyone wanted it.
-
-Bulletins, net announcements, reference material, and logs all fit that shape. Time-critical alerts do not, which is why emergency and severe weather alerting stays on a channel.
-
-## Label it as a bot
-
-Put `bot` in the node name, and in the short name where the app has one. A reader scanning a channel can then separate scripted traffic from human traffic without knowing the nodes.
-
-## Public channel traffic
-
-Emergency and severe weather alerting is the case that justifies the public channel: low volume, high value, no reply loop.
-
-Coordinate before running one. Duplicate relays of the same feed multiply traffic without adding information, and an alert scoped to one county floods the state unless something limits it. Ask on Discord first.
-
-## Channel names
-
-The everyday channels use the same names on both networks. The lists, keys, and add links are in [MeshCore Node Configuration]({{< relref "/docs/meshcore/configuration/index.md" >}}#channels) and [Meshtastic Node Configuration]({{< relref "/docs/meshtastic/configuration/index.md" >}}#channels).
+- [Mesh Monitor](https://meshmonitor.org). Self-hosted web dashboard for Meshtastic, MeshCore, and MQTT sources in one deployment: maps, messaging, telemetry, and remote device administration. Its automation covers auto-responders, scheduled messages, auto-traceroute, geofence triggers, and push notifications, extensible with Python or Bash scripts.
+- [meshing-around](https://github.com/SpudGunMan/meshing-around). Python bot suite for Meshtastic, run over serial, TCP, or BLE across multiple nodes. Keyword responder, BBS with mail and store-and-forward, scheduled messages, NOAA and USGS weather, river, tide and earthquake lookups, EAS alerts, wiki and satellite pass queries, proximity alerts, network and hardware test commands, optional LLM integration, and games.
+- [Meshtastic SAME EAS Alerter](https://github.com/RCGV1/Meshtastic-SAME-EAS-Alerter). Decodes SAME emergency alerts off the air with an RTL-SDR and forwards them to a node over serial or TCP. No internet connection required.

--- a/content/docs/meshcore/_index.md
+++ b/content/docs/meshcore/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Meshcore Docs
+title: MeshCore Docs
 menu:
   main:
     parent: docs
@@ -11,4 +11,4 @@ menu:
         color: blue
 ---
 
-Meshcore documentation and guides.
+MeshCore documentation and guides.

--- a/content/docs/meshcore/configuration/index.md
+++ b/content/docs/meshcore/configuration/index.md
@@ -58,13 +58,22 @@ The CLI equivalent is `set path.hash.mode 1`.
 
 ## Channels
 
-`Public` is built in. Florida also uses:
+Florida uses:
 
-`#emergency` · `#hamradio` · `#testing` · `#florida` · `#weather` · `#weekly-mesh-net`
+| Channel | Key | Region Scope | Purpose |
+|---|---|---|---|
+| [`Public`](meshcore://channel/add?name=Public&secret=8b3387e9c5cdea6ac9e5edbaa115cd72) | `8b3387e9c5cdea6ac9e5edbaa115cd72` | | Built in, general traffic |
+| [`FloridaMesh`](meshcore://channel/add?name=FloridaMesh&secret=e9a7128005b364ae010dd6330d693fa6) | `e9a7128005b364ae010dd6330d693fa6` | | Statewide chat |
+| [`#emergency`](meshcore://channel/add?name=%23emergency&secret=e1ad578d25108e344808f30dfdaaf926) | `e1ad578d25108e344808f30dfdaaf926` | | Emergency and severe weather traffic |
+| [`#weather`](meshcore://channel/add?name=%23weather&secret=88f502554fee92a1625cfb311546e7cb) | `88f502554fee92a1625cfb311546e7cb` | | Weather scripts and alerting |
+| [`#testing`](meshcore://channel/add?name=%23testing&secret=cde5e82cf515647dcb547a79a4f065d1) | `cde5e82cf515647dcb547a79a4f065d1` | | Node, script, and bot testing |
+| [`#weekly-mesh-net`](meshcore://channel/add?name=%23weekly-mesh-net&secret=284d8129d937833bdd641f21256dced0) | `284d8129d937833bdd641f21256dced0` | | [Weekly Mesh Net]({{< relref "/docs/general/weekly-mesh-net/index.md" >}}) |
 
-Add them with *Add Channel → Join a Hashtag Channel* or a QR code; there is no CLI to add channels. A hashtag channel derives its key from its name, so every node joining by the same name lands on the same channel. These are shared public channels, not private ones. `#weekly-mesh-net` carries the [Weekly Mesh Net]({{< relref "/docs/general/weekly-mesh-net/index.md" >}}).
+Open a channel name on a device with the MeshCore app installed to add it directly. Otherwise: `Public` is built in and needs nothing entered, the hashtag channels derive their key from their name so *Add Channel → Join a Hashtag Channel* or a QR code is enough, and `FloridaMesh` is private, so enter its name and key exactly as shown or scan a QR code. There is no CLI to add channels.
 
 Join the ones you intend to use. There is no cost to joining a channel you rarely read, and traffic on it reaches you either way.
+
+Bots and scripts that chat back and forth belong on `#testing` or a private channel. Leave `#emergency` clear for real emergencies. See [Bots and Automation]({{< relref "/docs/general/bots-and-automation/index.md" >}}).
 
 If you run Meshmapper, list every channel you know of under **Public Channels** in its admin settings. That is what the wardriving app listens on for passive RX logs, and a longer list means more coverage recorded for the same drive.
 
@@ -138,3 +147,19 @@ Transmit power, range `1`–`22` dBm. The default varies by board.
 This value sets the transceiver's output, not the antenna's. On boards with a power amplifier the radiated power is substantially higher than the number you set. Establish your board's PA gain and your applicable limits before raising it. Driving a PA beyond its rating, or transmitting into a bad or missing antenna, will permanently damage the radio.
 
 Raising TX power does not fix an asymmetric link. If you can hear a repeater but it cannot hear you, the deficit is usually antenna, feedline, or siting, not power.
+
+## FAQ
+
+### I receive too many notifications on a channel
+
+Nothing is wrong with your node. A busy channel is a busy channel, and what it does to your phone is yours to control.
+
+Open the channel, then **Channel Settings**:
+
+- **Notifications** sets what the channel is allowed to interrupt you for: *All Messages*, *Mentions Only*, or *None*. Messages keep arriving either way, you just stop being told about each one.
+- **Blocked Senders** silences one particular node, which is the right tool when a single chatty bot is the problem rather than the channel.
+- **Message Retention** limits how much history the app keeps.
+
+If you have no use for the channel at all, remove it from your channel list. You can add it back any time from the key or link above.
+
+None of this affects anyone else on the mesh.

--- a/content/docs/meshcore/configuration/index.md
+++ b/content/docs/meshcore/configuration/index.md
@@ -69,11 +69,11 @@ Florida uses:
 | [`#testing`](meshcore://channel/add?name=%23testing&secret=cde5e82cf515647dcb547a79a4f065d1) | `cde5e82cf515647dcb547a79a4f065d1` | | Node, script, and bot testing |
 | [`#weekly-mesh-net`](meshcore://channel/add?name=%23weekly-mesh-net&secret=284d8129d937833bdd641f21256dced0) | `284d8129d937833bdd641f21256dced0` | | [Weekly Mesh Net]({{< relref "/docs/general/weekly-mesh-net/index.md" >}}) |
 
-Open a channel name on a device with the MeshCore app installed to add it directly. Otherwise: `Public` is built in and needs nothing entered, the hashtag channels derive their key from their name so *Add Channel → Join a Hashtag Channel* or a QR code is enough, and `FloridaMesh` is private, so enter its name and key exactly as shown or scan a QR code. There is no CLI to add channels.
+Open a channel name on a device with the app installed to add it directly. Otherwise: `Public` is built in, the hashtag channels derive their key from their name so *Add Channel → Join a Hashtag Channel* or a QR code is enough, and `FloridaMesh` is private, so enter its name and key exactly as listed. There is no CLI to add channels.
 
 Join the ones you intend to use. There is no cost to joining a channel you rarely read, and traffic on it reaches you either way.
 
-Bots and scripts that chat back and forth belong on `#testing` or a private channel. Leave `#emergency` clear for real emergencies. See [Bots and Automation]({{< relref "/docs/general/bots-and-automation/index.md" >}}).
+Bot-to-bot traffic goes on `#testing` or a private channel; keep `#emergency` clear. See [Bots and Automation]({{< relref "/docs/general/bots-and-automation/index.md" >}}).
 
 If you run Meshmapper, list every channel you know of under **Public Channels** in its admin settings. That is what the wardriving app listens on for passive RX logs, and a longer list means more coverage recorded for the same drive.
 
@@ -152,14 +152,10 @@ Raising TX power does not fix an asymmetric link. If you can hear a repeater but
 
 ### I receive too many notifications on a channel
 
-Nothing is wrong with your node. A busy channel is a busy channel, and what it does to your phone is yours to control.
+Notification behaviour is local to your phone. Open the channel, then **Channel Settings**:
 
-Open the channel, then **Channel Settings**:
+- **Notifications**: *All Messages*, *Mentions Only*, or *None*. Messages keep arriving either way.
+- **Blocked Senders**: silence one node rather than the whole channel, for a single chatty bot.
+- **Message Retention**: limit how much history the app keeps.
 
-- **Notifications** sets what the channel is allowed to interrupt you for: *All Messages*, *Mentions Only*, or *None*. Messages keep arriving either way, you just stop being told about each one.
-- **Blocked Senders** silences one particular node, which is the right tool when a single chatty bot is the problem rather than the channel.
-- **Message Retention** limits how much history the app keeps.
-
-If you have no use for the channel at all, remove it from your channel list. You can add it back any time from the key or link above.
-
-None of this affects anyone else on the mesh.
+To leave entirely, remove the channel from your channel list. Re-add it from the key or link above.

--- a/content/docs/meshcore/configuration/index.md
+++ b/content/docs/meshcore/configuration/index.md
@@ -67,13 +67,7 @@ Florida uses:
 | [`#testing`](meshcore://channel/add?name=%23testing&secret=cde5e82cf515647dcb547a79a4f065d1) | Derived from name | | Node, script, and bot testing |
 | [`#weekly-mesh-net`](meshcore://channel/add?name=%23weekly-mesh-net&secret=284d8129d937833bdd641f21256dced0) | Derived from name | | [Weekly Mesh Net]({{< relref "/docs/general/weekly-mesh-net/index.md" >}}) |
 
-Open a channel name on a device with the app installed to add it directly. Otherwise: `Public` is built in, the hashtag channels derive their key from their name so *Add Channel → Join a Hashtag Channel* or a QR code is enough, and `FloridaMesh` is private, so enter its name and key exactly as listed. There is no CLI to add channels.
-
-Join the ones you intend to use. There is no cost to joining a channel you rarely read, and traffic on it reaches you either way.
-
-Bot traffic goes on `#testing` or a private channel; keep `#emergency` clear. See [Bots and Automation]({{< relref "/docs/general/bots-and-automation/index.md" >}}).
-
-If you run Meshmapper, list every channel you know of under **Public Channels** in its admin settings. That is what the wardriving app listens on for passive RX logs, and a longer list means more coverage recorded for the same drive.
+Open this page in your phone's browser and tap a channel name to hand it straight to the MeshCore app, which opens with the name and key already filled in. To add one by hand instead: `Public` is built in and needs nothing entered, the hashtag channels derive their key from their name, so *Add Channel → Join a Hashtag Channel* or a QR code is enough, and `FloridaMesh` is private, so enter its name and key exactly as listed. There is no CLI to add channels.
 
 ## Region scopes
 

--- a/content/docs/meshcore/configuration/index.md
+++ b/content/docs/meshcore/configuration/index.md
@@ -18,6 +18,14 @@ Companion nodes are configured in the app. Repeaters and room servers are config
 
 <!--more-->
 
+## Firmware
+
+Flash from the [MeshCore flasher](https://flasher.meshcore.io) over USB, using Chrome or Edge. Select the board, then the firmware role: companion, repeater, or room server.
+
+{{< notice info "Use meshcore.io" >}}
+The project moved to `meshcore.io`. `meshcore.co.uk` is not affiliated with the official project and should not be used.
+{{< /notice >}}
+
 ## Companion nodes
 
 If your node is paired to your phone, this section plus [Channels](#channels) is the whole setup. Nothing in the repeater section applies to you.

--- a/content/docs/meshcore/configuration/index.md
+++ b/content/docs/meshcore/configuration/index.md
@@ -1,5 +1,6 @@
 ---
 title: Node Configuration
+linkTitle: Configuration
 description: Configuring MeshCore companion clients and repeater infrastructure for the Florida Mesh.
 nav_weight: 3
 authors:
@@ -22,8 +23,8 @@ Companion nodes are configured in the app. Repeaters and room servers are config
 
 Flash from the [MeshCore flasher](https://flasher.meshcore.io) over USB, using Chrome or Edge. Select the board, then the firmware role: companion, repeater, or room server.
 
-{{< notice info "Use meshcore.io" >}}
-The project moved to `meshcore.io`. `meshcore.co.uk` is not affiliated with the official project and should not be used.
+{{< notice note "Use meshcore.io" >}}
+The project moved to `meshcore.io`. `meshcore.co.uk` is no longer affiliated with the official project.
 {{< /notice >}}
 
 ## Companion nodes
@@ -47,17 +48,6 @@ Frequency, bandwidth, and spreading factor must match the rest of the mesh exact
 
 Settings → Experimental → **Hop Bytes: `2`**
 
-### Check your work
-
-- The radio screen reads `910.525` / `62.5` / `7` / `8`
-- Hop Bytes is `2`
-- The channels below are joined
-- Other nodes appear in your contact list
-
-That is the whole radio configuration for a companion node. Channels are next.
-
-### Why Hop Bytes 2
-
 Every hop a packet takes is recorded in its path as a short hash of the repeater that forwarded it. At 1 byte there are only 256 possible values, so in a mesh this size two repeaters routinely hash to the same byte, after which routing and telemetry cannot tell which one actually carried the packet. Two bytes gives 65,536 values and makes collisions rare.
 
 The cost is path length: each hop consumes two bytes of a fixed-size path field instead of one, reducing the maximum number of hops a route can record. Florida accepts that trade.
@@ -70,18 +60,18 @@ Florida uses:
 
 | Channel | Key | Region Scope | Purpose |
 |---|---|---|---|
-| [`Public`](meshcore://channel/add?name=Public&secret=8b3387e9c5cdea6ac9e5edbaa115cd72) | `8b3387e9c5cdea6ac9e5edbaa115cd72` | | Built in, general traffic |
+| [`Public`](meshcore://channel/add?name=Public&secret=8b3387e9c5cdea6ac9e5edbaa115cd72) | Built in | | General traffic |
 | [`FloridaMesh`](meshcore://channel/add?name=FloridaMesh&secret=e9a7128005b364ae010dd6330d693fa6) | `e9a7128005b364ae010dd6330d693fa6` | | Statewide chat |
-| [`#emergency`](meshcore://channel/add?name=%23emergency&secret=e1ad578d25108e344808f30dfdaaf926) | `e1ad578d25108e344808f30dfdaaf926` | | Emergency and severe weather traffic |
-| [`#weather`](meshcore://channel/add?name=%23weather&secret=88f502554fee92a1625cfb311546e7cb) | `88f502554fee92a1625cfb311546e7cb` | | Weather scripts and alerting |
-| [`#testing`](meshcore://channel/add?name=%23testing&secret=cde5e82cf515647dcb547a79a4f065d1) | `cde5e82cf515647dcb547a79a4f065d1` | | Node, script, and bot testing |
-| [`#weekly-mesh-net`](meshcore://channel/add?name=%23weekly-mesh-net&secret=284d8129d937833bdd641f21256dced0) | `284d8129d937833bdd641f21256dced0` | | [Weekly Mesh Net]({{< relref "/docs/general/weekly-mesh-net/index.md" >}}) |
+| [`#emergency`](meshcore://channel/add?name=%23emergency&secret=e1ad578d25108e344808f30dfdaaf926) | Derived from name | | Emergency and severe weather traffic |
+| [`#weather`](meshcore://channel/add?name=%23weather&secret=88f502554fee92a1625cfb311546e7cb) | Derived from name | | Weather scripts and alerting |
+| [`#testing`](meshcore://channel/add?name=%23testing&secret=cde5e82cf515647dcb547a79a4f065d1) | Derived from name | | Node, script, and bot testing |
+| [`#weekly-mesh-net`](meshcore://channel/add?name=%23weekly-mesh-net&secret=284d8129d937833bdd641f21256dced0) | Derived from name | | [Weekly Mesh Net]({{< relref "/docs/general/weekly-mesh-net/index.md" >}}) |
 
 Open a channel name on a device with the app installed to add it directly. Otherwise: `Public` is built in, the hashtag channels derive their key from their name so *Add Channel → Join a Hashtag Channel* or a QR code is enough, and `FloridaMesh` is private, so enter its name and key exactly as listed. There is no CLI to add channels.
 
 Join the ones you intend to use. There is no cost to joining a channel you rarely read, and traffic on it reaches you either way.
 
-Bot-to-bot traffic goes on `#testing` or a private channel; keep `#emergency` clear. See [Bots and Automation]({{< relref "/docs/general/bots-and-automation/index.md" >}}).
+Bot traffic goes on `#testing` or a private channel; keep `#emergency` clear. See [Bots and Automation]({{< relref "/docs/general/bots-and-automation/index.md" >}}).
 
 If you run Meshmapper, list every channel you know of under **Public Channels** in its admin settings. That is what the wardriving app listens on for passive RX logs, and a longer list means more coverage recorded for the same drive.
 
@@ -105,7 +95,7 @@ set path.hash.mode 1
 
 `flood.advert.interval` is the number of hours between flood adverts, range `3`–`168`, default `12`. Shorter intervals put more advert traffic on the air for every repeater that relays them. `advert.interval` separately controls local zero-hop adverts, in minutes.
 
-`path.hash.mode` selects the path hash size: `0` = 1-byte, `1` = 2-byte, `2` = 3-byte. Florida uses 2-byte; see [Why Hop Bytes 2](#why-hop-bytes-2).
+`path.hash.mode` selects the path hash size: `0` = 1-byte, `1` = 2-byte, `2` = 3-byte. Florida uses 2-byte; see [Hop Bytes](#hop-bytes).
 
 Fixed position, for boards without GPS:
 
@@ -129,9 +119,9 @@ ver
 - `get radio` returns `910.525,62.5,7,8`
 - `ver` reports the firmware version, so you can confirm the node is running the one you intended
 
-### Troubleshooting
+## FAQ
 
-#### Repeater hears very little, or stops hearing traffic entirely
+### My repeater hears very little, or has stopped hearing traffic
 
 Two receive-side settings, neither of which is set by the modem preset.
 
@@ -144,7 +134,7 @@ set agc.reset.interval 12
 
 `agc.reset.interval` periodically restarts the receiver's automatic gain control. A strong nearby transmission can leave the AGC latched at low gain, after which the radio still appears healthy but no longer decodes weak signals, the classic "deaf repeater". The value is in seconds, rounded down to a multiple of 4, and defaults to `0` (disabled). `12` restores sensitivity on an unattended repeater without resetting so often that it clips traffic mid-reception.
 
-#### Poor range, or the node is not being heard
+### My node has poor range, or is not being heard
 
 ```shell {linenos=false}
 set tx <dBm>
@@ -155,8 +145,6 @@ Transmit power, range `1`–`22` dBm. The default varies by board.
 This value sets the transceiver's output, not the antenna's. On boards with a power amplifier the radiated power is substantially higher than the number you set. Establish your board's PA gain and your applicable limits before raising it. Driving a PA beyond its rating, or transmitting into a bad or missing antenna, will permanently damage the radio.
 
 Raising TX power does not fix an asymmetric link. If you can hear a repeater but it cannot hear you, the deficit is usually antenna, feedline, or siting, not power.
-
-## FAQ
 
 ### I receive too many notifications on a channel
 

--- a/content/docs/meshcore/regional-settings/index.md
+++ b/content/docs/meshcore/regional-settings/index.md
@@ -106,12 +106,4 @@ Each entry should show `F`, meaning flood allowed. On firmware older than `1.15.
 openHop Repeater does not implement any of these. Every `region` subcommand returns `Error: Region commands not implemented`, so manage regions in the openHop Console instead. Renaming an entry there keeps its original key, so delete it and add the new name rather than editing it.
 {{< /notice >}}
 
-### Further reading
-
-- [Region Filtering](https://blog.meshcore.io/2026/01/20/region-filtering)
-- [Default Scope Region](https://blog.meshcore.io/2026/04/17/default-scope)
-- [Proposal: predefined standardized region scopes](https://github.com/meshcore-dev/MeshCore/issues/2495)
-- [Regions, scopes, and the future of MeshCore](https://github.com/meshcore-dev/MeshCore/discussions/2375)
-- [Docs unclear on region behaviour](https://github.com/meshcore-dev/MeshCore/issues/1747)
-
 Application per node role is in [Node Configuration]({{< relref "/docs/meshcore/configuration/index.md" >}}).

--- a/content/docs/meshtastic/configuration/index.md
+++ b/content/docs/meshtastic/configuration/index.md
@@ -19,6 +19,32 @@ nav_icon:
 
 Below are configuration recommendations for optimizing your Meshtastic nodes for getting on the [Florida Mesh Map][MESHMAP] & [Florida Mesh Telemetry][MALLA].
 
+## Channels
+
+Alongside the primary channel, Florida uses:
+
+| Channel | Key | Purpose |
+|---|---|---|
+| [`FloridaMesh`](https://meshtastic.org/e/?add=true#CjcSIGXQsmeHp7fzWcnl7zY7Qb666dJQpaHVMoWKVS-MbIZwGgtGbG9yaWRhTWVzaCgBMAE6AggN) | `ZdCyZ4ent/NZyeXvNjtBvrrp0lClodUyhYpVL4xshnA=` | Statewide chat |
+| [`emergency`](https://meshtastic.org/e/?add=true#ChYSAQEaCWVtZXJnZW5jeSgBMAE6AggN) | `AQ==` | Emergency and severe weather traffic |
+| [`weather`](https://meshtastic.org/e/?add=true#Cg4SAQEaB3dlYXRoZXIoAQ) | `AQ==` | Weather scripts and alerting |
+| [`testing`](https://meshtastic.org/e/?add=true#Cg4SAQEaB3Rlc3RpbmcoAQ) | `AQ==` | Node, script, and bot testing |
+| [`telemetry`](https://meshtastic.org/e/?add=true#ChISAQEaCXRlbGVtZXRyeSgBOgA) | `AQ==` | Remote infrastructure nodes only, see below |
+
+Open a channel name on a device with the Meshtastic app installed to add it, or enter the name and key by hand as a secondary channel. The name and key together define the channel, so every node using the same name and key lands on the same one. Names are case sensitive and limited to 11 characters, and a node has eight channel slots including the primary.
+
+{{< notice note >}}
+These are `?add=true` links. They add the one channel and leave your existing channels and radio settings alone.
+
+A `meshtastic.org/e/` link without `?add=true` is a *replace* link: it wipes every channel you have, makes its first channel your primary, and overwrites your LoRa configuration including region, hop limit, and TX power. Check for `?add=true` before scanning a link or QR code from anyone.
+{{< /notice >}}
+
+### telemetry
+
+Skip this one unless you run remote infrastructure. Neighbor Info will not transmit over LoRa while your primary channel is the default public channel, so a remote infrastructure node that needs to share neighbor data adds `telemetry` and makes it its **primary**, not a secondary. Normal nodes have no use for it.
+
+Join the ones you intend to use. The [Weekly Mesh Net]({{< relref "docs/general/weekly-mesh-net/index.md" >}}) stays on your region's default public channel. Bots and scripts that chat back and forth belong on `testing` or a private channel, not the primary. Leave `emergency` clear for real emergencies. See [Bots and Automation]({{< relref "docs/general/bots-and-automation/index.md" >}}).
+
 ## Getting on the Map In Existing Meshes
 
 For nodes that are in established meshes (please check [Florida Mesh Map][MESHMAP] to see where the closest feeders are) all you need to get added to the maps and tools is one config change.
@@ -54,6 +80,20 @@ Channels:
   - Precise Location: *user preference*
   - Precision Slider: *user preference*
   
+Uplink and downlink are set per channel. What each of the Florida channels expects:
+
+| Channel | Uplink | Downlink | Zero-hopped |
+|---|---|---|---|
+| primary (`LongFast`) | `Checked` | `Unchecked` | Yes |
+| `FloridaMesh` | `Checked` | `Checked` | No |
+| `emergency` | `Checked` | `Checked` | No |
+| `weather`, `testing` | `Checked` | `Unchecked` | No |
+| `telemetry` | `Checked` | `Unchecked` | Yes |
+
+`FloridaMesh` carries downlink so that a message put on it reaches operators anywhere in the state rather than only those within radio range of the sender. `emergency` carries downlink for the same reason and a sharper one: when it matters, the information needs to travel as far as it can.
+
+The [Florida broker](https://github.com/flmesh/emqx) zeroes `hop_limit` and `hop_start` in flight on the default modem-preset channels and on `telemetry`. A packet the broker delivers on those reaches only the nodes that hear a gateway directly and is not rebroadcast, which is what keeps internet-scale traffic from flooding the radio mesh. `FloridaMesh` and `emergency` are not zero-hopped, so traffic downlinked on them travels the mesh normally.
+
 Device:
 
 - Role: `CLIENT|CLIENT_BASE|CLIENT_MUTE`[^role]
@@ -125,6 +165,18 @@ If your node is not appearing on the map:
 - Ensure the precision settings meet the minimum requirements (1194ft / 363m)
 - Confirm the root topic is set exactly to `msh/US/FL`
 - Verify the MQTT module is enabled and properly configured
+
+## FAQ
+
+### I receive too many notifications on a channel
+
+Nothing is wrong with your node. A busy channel is a busy channel, and you control what it does to your phone.
+
+- Mute the conversation. In the message list, select the channel and choose **Mute notifications**, for 8 hours, 1 week, or always. Messages still arrive, your phone stays quiet.
+- Turn off notifications for the Meshtastic app in your phone's own settings if you would rather check messages when you open the app.
+- Leave the channel. Delete it in the app's channel settings and that slot is free for something else. You can rejoin later with the name and key above.
+
+Muting or leaving a channel changes nothing for anyone else on the mesh, and it does not stop your node from relaying traffic.
 
 [^presets]: Please reference [Regional LoRa Settings]({{< relref "regional-lora-settings/index.md" >}}) for up to date modem presets for each area of the state.
 [^tls]: TLS encrypts data transmitted between MQTT clients and the broker for increased security, but may not supported on all platforms. It is known that the Android App version above 2.7.13 may have issues with TLS enabled.

--- a/content/docs/meshtastic/configuration/index.md
+++ b/content/docs/meshtastic/configuration/index.md
@@ -33,21 +33,11 @@ Alongside the primary channel, Florida uses:
 | [`emergency`](https://meshtastic.org/e/?add=true#ChYSAQEaCWVtZXJnZW5jeSgBMAE6AggN) | `AQ==` | Emergency and severe weather traffic |
 | [`weather`](https://meshtastic.org/e/?add=true#Cg4SAQEaB3dlYXRoZXIoAQ) | `AQ==` | Weather scripts and alerting |
 | [`testing`](https://meshtastic.org/e/?add=true#Cg4SAQEaB3Rlc3RpbmcoAQ) | `AQ==` | Node, script, and bot testing |
-| [`telemetry`](https://meshtastic.org/e/?add=true#ChISAQEaCXRlbGVtZXRyeSgBOgA) | `AQ==` | Remote infrastructure nodes only, see below |
+| [`telemetry`](https://meshtastic.org/e/?add=true#ChISAQEaCXRlbGVtZXRyeSgBOgA) | `AQ==` | Remote infrastructure nodes only[^telemetry] |
 
 Open a channel name on a device with the app installed to add it, or enter the name and key by hand as a secondary channel. Name and key together define the channel: same name, same key, same channel. Names are case sensitive and limited to 11 characters. A node has eight channel slots including the primary.
 
-The [Weekly Mesh Net]({{< relref "docs/general/weekly-mesh-net/index.md" >}}) runs on your region's default public channel, not on any of these. Bot-to-bot traffic goes on `testing` or a private channel; keep `emergency` clear. See [Bots and Automation]({{< relref "docs/general/bots-and-automation/index.md" >}}).
-
-{{< notice note "Check for ?add=true" >}}
-The links above are `?add=true`: each adds one channel and leaves your other channels and LoRa config untouched.
-
-A `meshtastic.org/e/` link *without* `?add=true` replaces the entire channel set, makes its first channel your primary, and overwrites LoRa config including region, hop limit, and TX power. Verify before scanning a link or QR code from anyone.
-{{< /notice >}}
-
-### telemetry
-
-Infrastructure only. Neighbor Info does not transmit over LoRa while the primary channel is the default one, so a remote infrastructure node sharing neighbor data sets `telemetry` as its **primary** rather than a secondary. The add link installs it as a secondary, where it has no effect.
+The [Weekly Mesh Net]({{< relref "docs/general/weekly-mesh-net/index.md" >}}) runs on your region's default public channel, not on any of these. Bot traffic goes on `testing` or a private channel; keep `emergency` clear. See [Bots and Automation]({{< relref "docs/general/bots-and-automation/index.md" >}}).
 
 ## Getting on the Map In Existing Meshes
 
@@ -159,9 +149,9 @@ After configuring your device, you can verify that your telemetry is being prope
 2. Review your device debug logs for successful MQTT connection messages
 3. Confirm your device is sending position updates at the expected intervals
 
-## Troubleshooting
+## FAQ
 
-If your node is not appearing on the map:
+### My node is not appearing on the map
 
 - Verify internet connectivity on the device
 - If its a NRF52 based node confirm that `Proxy to Client` is enabled.
@@ -169,8 +159,6 @@ If your node is not appearing on the map:
 - Ensure the precision settings meet the minimum requirements (1194ft / 363m)
 - Confirm the root topic is set exactly to `msh/US/FL`
 - Verify the MQTT module is enabled and properly configured
-
-## FAQ
 
 ### I receive too many notifications on a channel
 
@@ -180,6 +168,7 @@ Notification behaviour is local to your phone. Messages keep arriving either way
 - **Disable notifications for the app** in your phone's settings.
 - **Remove the channel** in the app's channel settings, freeing the slot. Rejoin later with the name and key above.
 
+[^telemetry]: Neighbor Info does not transmit over LoRa while the primary channel is the default one, so a remote infrastructure node sharing neighbor data sets `telemetry` as its **primary** rather than a secondary. The add link installs it as a secondary, where it has no effect.
 [^presets]: Please reference [Regional LoRa Settings]({{< relref "regional-lora-settings/index.md" >}}) for up to date modem presets for each area of the state.
 [^tls]: TLS encrypts data transmitted between MQTT clients and the broker for increased security, but may not supported on all platforms. It is known that the Android App version above 2.7.13 may have issues with TLS enabled.
 [^ninfo]: Please only enable Neighbor Info on Basestation and stationary nodes, when enabled on mobile nodes it causes a lot of noise and clutter to the map. Thank you.

--- a/content/docs/meshtastic/configuration/index.md
+++ b/content/docs/meshtastic/configuration/index.md
@@ -31,19 +31,19 @@ Alongside the primary channel, Florida uses:
 | [`testing`](https://meshtastic.org/e/?add=true#Cg4SAQEaB3Rlc3RpbmcoAQ) | `AQ==` | Node, script, and bot testing |
 | [`telemetry`](https://meshtastic.org/e/?add=true#ChISAQEaCXRlbGVtZXRyeSgBOgA) | `AQ==` | Remote infrastructure nodes only, see below |
 
-Open a channel name on a device with the Meshtastic app installed to add it, or enter the name and key by hand as a secondary channel. The name and key together define the channel, so every node using the same name and key lands on the same one. Names are case sensitive and limited to 11 characters, and a node has eight channel slots including the primary.
+Open a channel name on a device with the app installed to add it, or enter the name and key by hand as a secondary channel. Name and key together define the channel: same name, same key, same channel. Names are case sensitive and limited to 11 characters. A node has eight channel slots including the primary.
 
-{{< notice note >}}
-These are `?add=true` links. They add the one channel and leave your existing channels and radio settings alone.
+The [Weekly Mesh Net]({{< relref "docs/general/weekly-mesh-net/index.md" >}}) runs on your region's default public channel, not on any of these. Bot-to-bot traffic goes on `testing` or a private channel; keep `emergency` clear. See [Bots and Automation]({{< relref "docs/general/bots-and-automation/index.md" >}}).
 
-A `meshtastic.org/e/` link without `?add=true` is a *replace* link: it wipes every channel you have, makes its first channel your primary, and overwrites your LoRa configuration including region, hop limit, and TX power. Check for `?add=true` before scanning a link or QR code from anyone.
+{{< notice note "Check for ?add=true" >}}
+The links above are `?add=true`: each adds one channel and leaves your other channels and LoRa config untouched.
+
+A `meshtastic.org/e/` link *without* `?add=true` replaces the entire channel set, makes its first channel your primary, and overwrites LoRa config including region, hop limit, and TX power. Verify before scanning a link or QR code from anyone.
 {{< /notice >}}
 
 ### telemetry
 
-Skip this one unless you run remote infrastructure. Neighbor Info will not transmit over LoRa while your primary channel is the default public channel, so a remote infrastructure node that needs to share neighbor data adds `telemetry` and makes it its **primary**, not a secondary. Normal nodes have no use for it.
-
-Join the ones you intend to use. The [Weekly Mesh Net]({{< relref "docs/general/weekly-mesh-net/index.md" >}}) stays on your region's default public channel. Bots and scripts that chat back and forth belong on `testing` or a private channel, not the primary. Leave `emergency` clear for real emergencies. See [Bots and Automation]({{< relref "docs/general/bots-and-automation/index.md" >}}).
+Infrastructure only. Neighbor Info does not transmit over LoRa while the primary channel is the default one, so a remote infrastructure node sharing neighbor data sets `telemetry` as its **primary** rather than a secondary. The add link installs it as a secondary, where it has no effect.
 
 ## Getting on the Map In Existing Meshes
 
@@ -80,7 +80,7 @@ Channels:
   - Precise Location: *user preference*
   - Precision Slider: *user preference*
   
-Uplink and downlink are set per channel. What each of the Florida channels expects:
+Uplink and downlink are per channel:
 
 | Channel | Uplink | Downlink | Zero-hopped |
 |---|---|---|---|
@@ -90,9 +90,9 @@ Uplink and downlink are set per channel. What each of the Florida channels expec
 | `weather`, `testing` | `Checked` | `Unchecked` | No |
 | `telemetry` | `Checked` | `Unchecked` | Yes |
 
-`FloridaMesh` carries downlink so that a message put on it reaches operators anywhere in the state rather than only those within radio range of the sender. `emergency` carries downlink for the same reason and a sharper one: when it matters, the information needs to travel as far as it can.
+`FloridaMesh` and `emergency` take downlink so traffic on them reaches the whole state instead of only nodes in radio range of the sender.
 
-The [Florida broker](https://github.com/flmesh/emqx) zeroes `hop_limit` and `hop_start` in flight on the default modem-preset channels and on `telemetry`. A packet the broker delivers on those reaches only the nodes that hear a gateway directly and is not rebroadcast, which is what keeps internet-scale traffic from flooding the radio mesh. `FloridaMesh` and `emergency` are not zero-hopped, so traffic downlinked on them travels the mesh normally.
+The [Florida broker](https://github.com/flmesh/emqx) zeroes `hop_limit` and `hop_start` in flight on the default modem-preset channels and on `telemetry`. Packets it delivers on those reach only nodes hearing a gateway directly and are not rebroadcast, so MQTT traffic cannot flood the radio mesh. `FloridaMesh` and `emergency` are not zero-hopped; downlinked traffic on them propagates at its hop limit.
 
 Device:
 
@@ -170,13 +170,11 @@ If your node is not appearing on the map:
 
 ### I receive too many notifications on a channel
 
-Nothing is wrong with your node. A busy channel is a busy channel, and you control what it does to your phone.
+Notification behaviour is local to your phone. Messages keep arriving either way, and your node keeps relaying traffic for the mesh.
 
-- Mute the conversation. In the message list, select the channel and choose **Mute notifications**, for 8 hours, 1 week, or always. Messages still arrive, your phone stays quiet.
-- Turn off notifications for the Meshtastic app in your phone's own settings if you would rather check messages when you open the app.
-- Leave the channel. Delete it in the app's channel settings and that slot is free for something else. You can rejoin later with the name and key above.
-
-Muting or leaving a channel changes nothing for anyone else on the mesh, and it does not stop your node from relaying traffic.
+- **Mute the conversation.** Select the channel in the message list, then **Mute notifications**: 8 hours, 1 week, or always.
+- **Disable notifications for the app** in your phone's settings.
+- **Remove the channel** in the app's channel settings, freeing the slot. Rejoin later with the name and key above.
 
 [^presets]: Please reference [Regional LoRa Settings]({{< relref "regional-lora-settings/index.md" >}}) for up to date modem presets for each area of the state.
 [^tls]: TLS encrypts data transmitted between MQTT clients and the broker for increased security, but may not supported on all platforms. It is known that the Android App version above 2.7.13 may have issues with TLS enabled.

--- a/content/docs/meshtastic/configuration/index.md
+++ b/content/docs/meshtastic/configuration/index.md
@@ -19,6 +19,10 @@ nav_icon:
 
 Below are configuration recommendations for optimizing your Meshtastic nodes for getting on the [Florida Mesh Map][MESHMAP] & [Florida Mesh Telemetry][MALLA].
 
+## Firmware
+
+Flash from the [Meshtastic web flasher](https://flasher.meshtastic.org) over USB, using Chrome or Edge. The [flashing documentation](https://meshtastic.org/docs/getting-started/flashing-firmware/) covers ESP32 and nRF52/RP2040/RP2350 boards separately; the procedure differs by family. Install the serial drivers first if the board is not detected.
+
 ## Channels
 
 Alongside the primary channel, Florida uses:

--- a/content/telemetry/meshcore.md
+++ b/content/telemetry/meshcore.md
@@ -1,5 +1,5 @@
 ---
-title: Meshcore Telemetry
+title: MeshCore Telemetry
 type: docs
 date: 2025-02-27T23:16:40+00:00
 ---


### PR DESCRIPTION
Closes #144.

## Bots and Automation (new page, General Docs)

Network-agnostic guidance covering any non-human response: auto-replies, scripts, alerting integrations, and AI agents.

Opens with where automation earns its airtime (severe weather and emergency alerting, range validation, equipment testing, onboarding, proximity alerts), notes that not all of it belongs on every channel, and states the constraint: one frequency shared by every node in range, used again by each repeater that forwards a packet.

**Best Practices** is the body of the page: keep the emergency channels clear, label the node with `bot`, reply by direct message, use tapbacks, avoid the default public channel, keep replies concise, consider your reach on MQTT uplinked channels, start small and private, and use a BBS or Room Server for pull-style content.

The direct-message bullet notes that both networks route later messages along a learned path instead of flooding, linked to [Meshtastic's next-hop routing](https://meshtastic.org/docs/overview/mesh-algo/) and [MeshCore's path discovery](https://docs.meshcore.io/faq/).

Closes with three projects: Mesh Monitor, meshing-around, and the Meshtastic SAME EAS Alerter.

## Channel tables

Both configuration pages list the Florida channels with purposes and one-tap add links.

**MeshCore** gains `Public` and `FloridaMesh`, a Region Scope column left blank for now, and `meshcore://channel/add` links. `#florida` is dropped in favour of `FloridaMesh`; `#hamradio` is removed. The Key column now prints only what a reader has to enter: `Public` is "Built in", the hashtag channels are "Derived from name", and `FloridaMesh` shows its key because it is the one that needs manual entry.

**Meshtastic** gains a Channels section it did not have, listing `FloridaMesh`, `emergency`, `weather`, `testing`, and `telemetry`. Every link is `?add=true` form, which adds the single channel and leaves the reader's other channels and LoRa configuration alone. `telemetry` carries a footnote explaining that it is infrastructure only: Neighbor Info does not transmit over LoRa while the primary channel is the default one, so an infrastructure node sets it as its primary rather than a secondary.

## MQTT section

Per-channel uplink and downlink, plus which channels the broker zero-hops. `FloridaMesh` and `emergency` take downlink so their traffic reaches the whole state; the default modem-preset channels and `telemetry` are zero-hopped, matching `channel_blacklist` in [flmesh/emqx](https://github.com/flmesh/emqx/blob/main/floodgate/config.yaml).

## Firmware

New section on each configuration page linking the respective web flasher, with a note on the MeshCore page that the project moved to `meshcore.io` and that `meshcore.co.uk` is no longer affiliated.

## FAQ

Both configuration pages now end in an FAQ rather than a Troubleshooting section. Meshtastic covers a node not appearing on the map and tuning notifications on a busy channel; MeshCore covers a deaf repeater, poor range, and notifications. Each uses its own app's wording.

## Housekeeping

- MeshCore capitalisation fixed in the docs nav, the Docs landing page, and the telemetry page title
- `linkTitle: Configuration` on the MeshCore configuration page, matching Meshtastic's nav label
- Removed the Further reading list from Regional Settings and the Check your work block from MeshCore Node Configuration
- Folded Why Hop Bytes 2 into the Hop Bytes section, updating the one inbound anchor

## Font fix

`config/_default/params.yaml` requested Google Fonts as `family=Ubuntu` with no weight axis, which returns the 400 face only. The theme styles `strong` as `font-weight: bolder`, so with no bold face available every bold run and heading on the site rendered at regular weight. Now requests `wght@400;700`.

---

Builds clean with `hugo --cleanDestinationDir`, so every `relref` resolves. The Meshtastic and MeshCore sections do not reference each other; shared material lives on the General Docs page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
